### PR TITLE
PIXBR-359 adding datadog logger

### DIFF
--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -11,23 +11,23 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
 
   @processed_metadata_keys ~w[pid file line function module application]a
 
-  def format_event(level, msg, ts, md, md_keys) do
+  def format_event(level, message, timestamp, metadata, metadata_keys) do
     Map.merge(
       %{
         logger:
           json_map(
-            thread_name: inspect(Keyword.get(md, :pid)),
-            method_name: method_name(md)
+            thread_name: inspect(Keyword.get(metadata, :pid)),
+            method_name: method_name(metadata)
           ),
-        msg: "#{IO.chardata_to_string(msg)}",
+        msg: "#{IO.chardata_to_string(message)}",
         syslog:
           json_map(
             hostname: node_hostname(),
             severity: Atom.to_string(level),
-            timestamp: FormatterUtils.format_timestamp(ts)
+            timestamp: FormatterUtils.format_timestamp(timestamp)
           )
       },
-      format_metadata(md, md_keys)
+      format_metadata(metadata, metadata_keys)
     )
   end
 

--- a/lib/logger_json/formatters/datadog_logger.ex
+++ b/lib/logger_json/formatters/datadog_logger.ex
@@ -14,16 +14,18 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
   def format_event(level, msg, ts, md, md_keys) do
     Map.merge(
       %{
-        logger: json_map(
-          thread_name: inspect(Keyword.get(md, :pid)),
-          method_name: method_name(md)
-        ),
-        message: IO.chardata_to_string(msg),
-        syslog: json_map(
-          hostname: node_hostname(),
-          severity: Atom.to_string(level),
-          timestamp: FormatterUtils.format_timestamp(ts)
-        )
+        logger:
+          json_map(
+            thread_name: inspect(Keyword.get(md, :pid)),
+            method_name: method_name(md)
+          ),
+        msg: "#{IO.chardata_to_string(msg)}",
+        syslog:
+          json_map(
+            hostname: node_hostname(),
+            severity: Atom.to_string(level),
+            timestamp: FormatterUtils.format_timestamp(ts)
+          )
       },
       format_metadata(md, md_keys)
     )
@@ -37,17 +39,18 @@ defmodule LoggerJSON.Formatters.DatadogLogger do
 
   defp format_error(md) do
     with %{reason: reason} <- FormatterUtils.format_process_crash(md) do
-      json_map(
-        stack: reason
-      )
+      json_map(stack: reason)
     end
   end
 
   defp method_name(metadata) do
     function = Keyword.get(metadata, :function)
     module = Keyword.get(metadata, :module)
+    line = Keyword.get(metadata, :line)
 
-    FormatterUtils.format_function(module, function)
+    [_ | last_module] = String.split("#{module}", ".")
+
+    "#{last_module}.#{function}::#{line}"
   end
 
   defp node_hostname do

--- a/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
+++ b/lib/logger_json/plug/metadata_formatters/datadog_logger.ex
@@ -12,33 +12,28 @@ if Code.ensure_loaded?(Plug) do
     @doc false
     def build_metadata(conn, latency, client_version_header) do
       client_metadata(conn, client_version_header) ++
-      phoenix_metadata(conn) ++
-      [
-        duration: native_to_nanoseconds(latency),
-        http:
-          json_map(
-            url: request_url(conn),
-            status_code: conn.status,
-            method: conn.method,
-            referer: LoggerJSON.Plug.get_header(conn, "referer"),
-            request_id: Keyword.get(Logger.metadata(), :request_id),
-            useragent: LoggerJSON.Plug.get_header(conn, "user-agent"),
-            url_details: json_map(
-              host: conn.host,
-              port: conn.port,
-              path: conn.request_path,
-              queryString: conn.query_string,
-              scheme: conn.scheme
-            )
-          ),
-        network:
-          json_map(
-            client:
-              json_map(
-                ip: remote_ip(conn)
-              )
-          )
-      ]
+        phoenix_metadata(conn) ++
+        [
+          duration: native_to_nanoseconds(latency),
+          http:
+            json_map(
+              url: request_url(conn),
+              status_code: conn.status,
+              method: conn.method,
+              referer: LoggerJSON.Plug.get_header(conn, "referer"),
+              request_id: Keyword.get(Logger.metadata(), :request_id),
+              useragent: LoggerJSON.Plug.get_header(conn, "user-agent"),
+              url_details:
+                json_map(
+                  host: conn.host,
+                  port: conn.port,
+                  path: conn.request_path,
+                  queryString: conn.query_string,
+                  scheme: conn.scheme
+                )
+            ),
+          network: json_map(client: json_map(ip: remote_ip(conn)))
+        ]
     end
 
     defp native_to_nanoseconds(nil) do

--- a/test/unit/logger_json_datadog_test.exs
+++ b/test/unit/logger_json_datadog_test.exs
@@ -53,7 +53,7 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => ""} = log
+    assert %{"msg" => ""} = log
   end
 
   test "logs binary messages" do
@@ -64,7 +64,7 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => "hello"} = log
+    assert %{"msg" => "hello"} = log
   end
 
   test "logs empty iodata messages" do
@@ -75,7 +75,7 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => ""} = log
+    assert %{"msg" => ""} = log
   end
 
   test "logs iodata messages" do
@@ -86,7 +86,7 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => "hello"} = log
+    assert %{"msg" => "hello"} = log
   end
 
   test "logs chardata messages" do
@@ -97,7 +97,7 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => "παβ"} = log
+    assert %{"msg" => "παβ"} = log
   end
 
   test "log message does not break escaping" do
@@ -108,14 +108,14 @@ defmodule LoggerJSONDatadogTest do
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => "\"h"} = log
+    assert %{"msg" => "\"h"} = log
 
     log =
       fn -> Logger.debug("\"h") end
       |> capture_log()
       |> Jason.decode!()
 
-    assert %{"message" => "\"h"} = log
+    assert %{"msg" => "\"h"} = log
   end
 
   test "does not start when there is no user" do
@@ -182,7 +182,7 @@ defmodule LoggerJSONDatadogTest do
         |> capture_log()
         |> Jason.decode!()
 
-      assert %{"message" => "hello"} = log
+      assert %{"msg" => "hello"} = log
     end
 
     test "ignore otp's metadata unixtime" do
@@ -247,7 +247,7 @@ defmodule LoggerJSONDatadogTest do
 
     assert %{
              "logger" => %{
-               "method_name" => ^function
+               "method_name" => "LoggerJSONDatadogTest.test contains source location/1::241"
              }
            } = log
   end

--- a/test/unit/logger_json_google_error_reporter_test.exs
+++ b/test/unit/logger_json_google_error_reporter_test.exs
@@ -28,7 +28,9 @@ defmodule LoggerJSONGoogleErrorReporterTest do
   end
 
   test "google_error_reporter metadata" do
-    :ok = Application.put_env(:logger_json, :google_error_reporter, service_context: [service: "myapp", version: "abc123"])
+    :ok =
+      Application.put_env(:logger_json, :google_error_reporter, service_context: [service: "myapp", version: "abc123"])
+
     log =
       capture_log(fn -> GoogleErrorReporter.report(:error, %RuntimeError{message: "oops"}, []) end)
       |> Jason.decode!()


### PR DESCRIPTION
# Proposal

**Jira Card:** [PIXBR-359](https://sumupteam.atlassian.net/browse/PIXBR-359)

This PR aims to configure a json format for our logs using LoggerJSON to improve usability in datadog.
Also, it adds more logs to transfer out flow.

## Implementation Details
We created a fork of the library [LoggerJSON](https://github.com/Nebo15/logger_json) so we can use it in house. 
We also created and configured a `datadog_logger` module based on [an existent formatter](https://github.com/Nebo15/logger_json/blob/master/lib/logger_json/formatters/datadog_logger.ex) (but still not released) from the same library.
By changing and customizing some log fields, datadog can now understand log severity, timestamp, mfa, etc as the image below:

![Screen Shot 2021-02-10 at 12 13 14](https://user-images.githubusercontent.com/498029/107533708-f5a1ef00-6b9d-11eb-8374-a1e692f8cd91.png)

To make it work, we changed the attribute `message` to `msg` and configured a message remapper in datadog specific for our service:

![Screen Shot 2021-02-10 at 12 47 57](https://user-images.githubusercontent.com/498029/107534000-444f8900-6b9e-11eb-94fc-e30e9d06ae9f.png)